### PR TITLE
Update install.osx.sh to use curl rather than wget

### DIFF
--- a/install/install.osx.sh
+++ b/install/install.osx.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 if [ -f "massren.osx.tar.gz" ]; then mv -f "massren.osx.tar.gz" "massren.osx.tar.gz.old" ; fi
-wget "https://github.com/laurent22/massren/releases/download/v1.0.1/massren.osx.tar.gz"
+curl -L -O "https://github.com/laurent22/massren/releases/download/v1.0.1/massren.osx.tar.gz"
 tar xvzf massren.osx.tar.gz
 chmod 755 massren
 mv massren /usr/bin


### PR DESCRIPTION
Curl is installed by default on Mac OS X, whereas Wget is not.

-L follows the redirect from Github to AWS.
