### PR TITLE
Simplify installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,14 +25,12 @@ The latest executables for each platform are available from the [release page](h
 ### OSX
 
 	curl -O https://raw.github.com/laurent22/massren/master/install/install.osx.sh
-	chmod 755 install.osx.sh
-	sudo ./install.osx.sh
+	sudo bash install.osx.sh
 
 ### Linux
 
 	curl -O https://raw.github.com/laurent22/massren/master/install/install.linux-amd64.sh
-	chmod 755 install.linux-amd64.sh
-	sudo ./install.linux-amd64.sh
+	sudo bash install.linux-amd64.sh
 
 ### Windows
 


### PR DESCRIPTION
Use

```
sudo bash script
```

instead of

```
chmod 755 script
sudo ./script
```

to skip the `chmod` step in the installation instructions.

I also removed some trailing whitespace in README.md.
