### PR TITLE
Fix tap name

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ The latest executables for each platform are available from the [release page](h
 
 #### Homebrew
 
-	brew tap laurent22/homebrew
+	brew tap laurent22/massren
 	brew install massren
 
 #### With the install script


### PR DESCRIPTION
Tap names e.g. `USER/REPO` map to clone URLs like `https://github.com/USER/homebrew-REPO`. There's no such repo as `laurent22/homebrew-homebrew`, so I'm guessing that you meant [`laurent22/homebrew-massren`](https://github.com/laurent22/homebrew-massren).
