### PR TITLE
Allow spaces in the editor path

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@ tests/
 .DS_Store
 testing/
 createfiles.sh
+.vscode

--- a/main.go
+++ b/main.go
@@ -130,7 +130,8 @@ func guessEditorCommand() (string, error) {
 	switch runtime.GOOS {
 
 	case "windows":
-
+		// The default editor for a given file extension is stored in a registry key: HKEY_CLASSES_ROOT/.txt/ShellNew/ItemName
+		// See this for hwo to in GO: http://stackoverflow.com/questions/18425465/enumerating-registry-values-in-go-golang
 		return "notepad.exe", nil
 
 	default: // assumes a POSIX system

--- a/main.go
+++ b/main.go
@@ -181,7 +181,8 @@ func editFile(filePath string) error {
 		}
 	}
 
-	pieces := strings.Split(editorCmd, " ")
+	pieces := make([]string, 0)
+	pieces = append(pieces, editorCmd)
 	pieces = append(pieces, filePath)
 	cmd := exec.Command(pieces[0], pieces[1:]...)
 	cmd.Stdin = os.Stdin


### PR DESCRIPTION
We can now have spaces in the path to the editor. (From #19 )
All tests by `go test` passed.
Tested on Windows and an Ubuntu 14.04 VM.
Not yet on OSX.