### PR TITLE
Spaces in path to editor working. Fixed #19

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,3 +16,4 @@ tests/
 testing/
 createfiles.sh
 .vscode
+run.sh

--- a/main.go
+++ b/main.go
@@ -180,10 +180,29 @@ func editFile(filePath string) error {
 			logInfo("No text editor defined in configuration. Using \"%s\" as default.\n%s", editorCmd, setupInfo)
 		}
 	}
-
-	pieces := strings.Split(editorCmd, " ")
-	pieces = append(pieces, filePath)
-	cmd := exec.Command(pieces[0], pieces[1:]...)
+	// Tokenize the editor path
+	token := strings.Split(editorCmd, " ")
+	var commandString string
+	// Iterate over all tokens
+	var pos int
+	for i := 0;i < cap(token);i++ {
+		// If the token is NOT a flag append a space to compensate for the trimmed spaces
+		// BUG: If more than one space occurs in a directory name, this will fail
+		if !(strings.HasPrefix(token[i], "-")) && !(strings.HasPrefix(token[i], "/")) {
+			token[i] += string(' ')
+			commandString += token[i]
+		} else {
+			// If the token IS a flag, break. We will handle it differently.
+			pos = i
+			break
+		}
+	}
+	// Make a slice to hold the arguments to the editor
+	var args []string
+	args = append(args, token[pos:]...)
+	args = append(args, filePath)
+	// Run the properly formed command
+	cmd := exec.Command(commandString, args[0:]...)
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = os.Stdout
 	err = cmd.Run()

--- a/main.go
+++ b/main.go
@@ -191,7 +191,7 @@ func parseEditorCommand(editorCmd string) (string, []string) {
 	var args []string
 	args = append(args, token[pos:]...)
 
-	return commandString, args
+	return strings.Trim(commandString, "\n\r\t "), args
 }
 
 func editFile(filePath string) error {
@@ -206,7 +206,7 @@ func editFile(filePath string) error {
 			logInfo("No text editor defined in configuration. Using \"%s\" as default.\n%s", editorCmd, setupInfo)
 		}
 	}
-	
+
 	commandString, args := parseEditorCommand(editorCmd)
 
 	args = append(args, filePath)

--- a/main.go
+++ b/main.go
@@ -168,18 +168,8 @@ func guessEditorCommand() (string, error) {
 	return "", errors.New("could not guess editor command")
 }
 
-func editFile(filePath string) error {
-	var err error
-	editorCmd := config_.String("editor")
-	if editorCmd == "" {
-		editorCmd, err = guessEditorCommand()
-		setupInfo := fmt.Sprintf("Run `%s --config editor \"name-of-editor\"` to set up the editor. eg. `%s --config editor \"vim\"`", APPNAME, APPNAME)
-		if err != nil {
-			criticalError(errors.New(fmt.Sprintf("No text editor defined in configuration, and could not guess a text editor.\n%s", setupInfo)))
-		} else {
-			logInfo("No text editor defined in configuration. Using \"%s\" as default.\n%s", editorCmd, setupInfo)
-		}
-	}
+// Returns the executable path and arguments
+func parseEditorCommand(editorCmd string) (string, []string) {
 	// Tokenize the editor path
 	token := strings.Split(editorCmd, " ")
 	var commandString string
@@ -200,6 +190,25 @@ func editFile(filePath string) error {
 	// Make a slice to hold the arguments to the editor
 	var args []string
 	args = append(args, token[pos:]...)
+
+	return commandString, args
+}
+
+func editFile(filePath string) error {
+	var err error
+	editorCmd := config_.String("editor")
+	if editorCmd == "" {
+		editorCmd, err = guessEditorCommand()
+		setupInfo := fmt.Sprintf("Run `%s --config editor \"name-of-editor\"` to set up the editor. eg. `%s --config editor \"vim\"`", APPNAME, APPNAME)
+		if err != nil {
+			criticalError(errors.New(fmt.Sprintf("No text editor defined in configuration, and could not guess a text editor.\n%s", setupInfo)))
+		} else {
+			logInfo("No text editor defined in configuration. Using \"%s\" as default.\n%s", editorCmd, setupInfo)
+		}
+	}
+	
+	commandString, args := parseEditorCommand(editorCmd)
+
 	args = append(args, filePath)
 	// Run the properly formed command
 	cmd := exec.Command(commandString, args[0:]...)

--- a/main_test.go
+++ b/main_test.go
@@ -266,6 +266,61 @@ ijkl
 	}
 }
 
+func Test_parseEditorCommand(t *testing.T) {
+	type TestCase struct {
+		editorCmd string
+		executable string
+		args  []string
+	}
+
+	var testCases []TestCase
+
+	testCases = append(testCases, TestCase{
+		editorCmd: "subl",
+		executable: "subl",
+		args: []string{},
+	})
+
+	testCases = append(testCases, TestCase{
+		editorCmd: "/usr/bin/vim -f",
+		executable: "/usr/bin/vim",
+		args: []string{ "-f" },
+	})
+
+	testCases = append(testCases, TestCase{
+		editorCmd: "\"F:\\Sublime Text 3\\sublime_text.exe\" /n /w",
+		executable: "F:\\Sublime Text 3\\sublime_text.exe",
+		args: []string{ "/n", "/w" },
+	})
+
+	testCases = append(testCases, TestCase{
+		editorCmd: "subl -w --command \"something with spaces\"",
+		executable: "subl",
+		args: []string{ "-w", "--command", "something with spaces" },
+	})
+
+	testCases = append(testCases, TestCase{
+		editorCmd: "notepad.exe /PT",
+		executable: "notepad.exe",
+		args: []string{ "/PT" },
+	})
+
+	for _, testCase := range testCases {
+		executable, args := parseEditorCommand(testCase.editorCmd)
+		if executable != testCase.executable {
+			t.Errorf("Expected '%s', got '%s'", testCase.executable, executable) 
+		}
+		if len(args) != len(testCase.args) {
+			t.Errorf("Expected and result args don't have the same length: [%s], [%s]", strings.Join(testCase.args, ", "), strings.Join(args, ", "))
+		}
+		for i, arg := range testCase.args {
+			if arg != args[i] {
+				t.Errorf("Expected and result args differ: [%s], [%s]", strings.Join(testCase.args, ", "), strings.Join(args, ", ")) 
+			}
+		}
+	}
+}
+
 func Test_processFileActions(t *testing.T) {
 	setup(t)
 	defer teardown(t)

--- a/main_test.go
+++ b/main_test.go
@@ -271,6 +271,7 @@ func Test_parseEditorCommand(t *testing.T) {
 		editorCmd string
 		executable string
 		args  []string
+		hasError bool
 	}
 
 	var testCases []TestCase
@@ -279,34 +280,63 @@ func Test_parseEditorCommand(t *testing.T) {
 		editorCmd: "subl",
 		executable: "subl",
 		args: []string{},
+		hasError: false,
 	})
 
 	testCases = append(testCases, TestCase{
 		editorCmd: "/usr/bin/vim -f",
 		executable: "/usr/bin/vim",
 		args: []string{ "-f" },
+		hasError: false,
 	})
 
 	testCases = append(testCases, TestCase{
 		editorCmd: "\"F:\\Sublime Text 3\\sublime_text.exe\" /n /w",
 		executable: "F:\\Sublime Text 3\\sublime_text.exe",
 		args: []string{ "/n", "/w" },
+		hasError: false,
 	})
 
 	testCases = append(testCases, TestCase{
 		editorCmd: "subl -w --command \"something with spaces\"",
 		executable: "subl",
 		args: []string{ "-w", "--command", "something with spaces" },
+		hasError: false,
 	})
 
 	testCases = append(testCases, TestCase{
 		editorCmd: "notepad.exe /PT",
 		executable: "notepad.exe",
 		args: []string{ "/PT" },
+		hasError: false,
+	})
+
+	testCases = append(testCases, TestCase{
+		editorCmd: "vim -e \"unclosed quote",
+		executable: "",
+		args: []string{},
+		hasError: true,
+	})
+
+	testCases = append(testCases, TestCase{
+		editorCmd: "subl -e 'unclosed single-quote",
+		executable: "",
+		args: []string{},
+		hasError: true,
+	})
+
+	testCases = append(testCases, TestCase{
+		editorCmd: "",
+		executable: "",
+		args: []string{},
+		hasError: true,
 	})
 
 	for _, testCase := range testCases {
-		executable, args := parseEditorCommand(testCase.editorCmd)
+		executable, args, err := parseEditorCommand(testCase.editorCmd)
+		if (err != nil && !testCase.hasError) || (err == nil && testCase.hasError) {
+			t.Errorf("Error status did not match: %b: %s", testCase.hasError, err)
+		}
 		if executable != testCase.executable {
 			t.Errorf("Expected '%s', got '%s'", testCase.executable, executable) 
 		}

--- a/version.go
+++ b/version.go
@@ -2,7 +2,7 @@ package main
 
 import "fmt"
 
-const VERSION = "1.4.0"
+const VERSION = "1.5.0"
 
 func handleVersionCommand(opts *CommandLineOptions, args []string) error {
 	fmt.Println(VERSION)


### PR DESCRIPTION
Review it before merging.

Tested inputs.
```
massren -c "C:/Program Files/Code/code.exe -R -o 2"
massren -c vim
massren -c "vim -R -O 2"
```

Basically:
- Quote the editor as long as spaces occur or you are supplying flags