### PR TITLE
Fix editor page whitespace

### DIFF
--- a/main.go
+++ b/main.go
@@ -666,7 +666,13 @@ func createListFileContent(filePaths []string, includeHeader bool) string {
 			if temp != "" {
 				temp += newline()
 			}
-			temp += "// " + line
+			//  If empty line we don't want white-space
+			if line == "" {
+				temp += "//"
+			} else {
+				temp += "// "
+			}
+			temp += line
 		}
 		header = temp + newline() + newline()
 	}

--- a/main.go
+++ b/main.go
@@ -488,10 +488,10 @@ func fileActions(originalFilePaths []string, changedContent string) ([]*FileActi
 				}
 			}
 
-			// Also OK if new path and old path are in fact the same file (for example if 
+			// Also OK if new path and old path are in fact the same file (for example if
 			// "/path/to/abcd" is going to be renamed to "/path/to/ABCD" on a case
 			// insensitive file system).
-			fileInfo2, err := os.Stat(action.FullOldPath());
+			fileInfo2, err := os.Stat(action.FullOldPath())
 			if err != nil {
 				return []*FileAction{}, errors.New(fmt.Sprintf("cannot stat \"%s\"", action.FullOldPath()))
 			}
@@ -568,7 +568,7 @@ func processFileActions(fileActions []*FileAction, dryRun bool) error {
 					action.intermediatePath = action.FullNewPath() + "-" + u.String()
 					conflictActions = append(conflictActions, action)
 				} else {
-					os.MkdirAll(filepath.Dir(action.FullNewPath()), 0755);
+					os.MkdirAll(filepath.Dir(action.FullNewPath()), 0755)
 					err := os.Rename(action.FullOldPath(), action.FullNewPath())
 					if err != nil {
 						return err

--- a/main_test.go
+++ b/main_test.go
@@ -250,7 +250,7 @@ ijkl
 				t.Errorf("Expected path %s, got %s", r2.oldPath, r1.oldPath)
 			}
 			if r1.newPath != r2.newPath {
-				t.Error("Expected path %s, got %s", r2.newPath, r1.newPath)
+				t.Errorf("Expected path %s, got %s", r2.newPath, r1.newPath)
 			}
 		}
 	}
@@ -335,7 +335,7 @@ func Test_parseEditorCommand(t *testing.T) {
 	for _, testCase := range testCases {
 		executable, args, err := parseEditorCommand(testCase.editorCmd)
 		if (err != nil && !testCase.hasError) || (err == nil && testCase.hasError) {
-			t.Errorf("Error status did not match: %b: %s", testCase.hasError, err)
+			t.Errorf("Error status did not match: %t: %s", testCase.hasError, err)
 		}
 		if executable != testCase.executable {
 			t.Errorf("Expected '%s', got '%s'", testCase.executable, executable)

--- a/main_test.go
+++ b/main_test.go
@@ -268,68 +268,68 @@ ijkl
 
 func Test_parseEditorCommand(t *testing.T) {
 	type TestCase struct {
-		editorCmd string
+		editorCmd  string
 		executable string
-		args  []string
-		hasError bool
+		args       []string
+		hasError   bool
 	}
 
 	var testCases []TestCase
 
 	testCases = append(testCases, TestCase{
-		editorCmd: "subl",
+		editorCmd:  "subl",
 		executable: "subl",
-		args: []string{},
-		hasError: false,
+		args:       []string{},
+		hasError:   false,
 	})
 
 	testCases = append(testCases, TestCase{
-		editorCmd: "/usr/bin/vim -f",
+		editorCmd:  "/usr/bin/vim -f",
 		executable: "/usr/bin/vim",
-		args: []string{ "-f" },
-		hasError: false,
+		args:       []string{"-f"},
+		hasError:   false,
 	})
 
 	testCases = append(testCases, TestCase{
-		editorCmd: "\"F:\\Sublime Text 3\\sublime_text.exe\" /n /w",
+		editorCmd:  "\"F:\\Sublime Text 3\\sublime_text.exe\" /n /w",
 		executable: "F:\\Sublime Text 3\\sublime_text.exe",
-		args: []string{ "/n", "/w" },
-		hasError: false,
+		args:       []string{"/n", "/w"},
+		hasError:   false,
 	})
 
 	testCases = append(testCases, TestCase{
-		editorCmd: "subl -w --command \"something with spaces\"",
+		editorCmd:  "subl -w --command \"something with spaces\"",
 		executable: "subl",
-		args: []string{ "-w", "--command", "something with spaces" },
-		hasError: false,
+		args:       []string{"-w", "--command", "something with spaces"},
+		hasError:   false,
 	})
 
 	testCases = append(testCases, TestCase{
-		editorCmd: "notepad.exe /PT",
+		editorCmd:  "notepad.exe /PT",
 		executable: "notepad.exe",
-		args: []string{ "/PT" },
-		hasError: false,
+		args:       []string{"/PT"},
+		hasError:   false,
 	})
 
 	testCases = append(testCases, TestCase{
-		editorCmd: "vim -e \"unclosed quote",
+		editorCmd:  "vim -e \"unclosed quote",
 		executable: "",
-		args: []string{},
-		hasError: true,
+		args:       []string{},
+		hasError:   true,
 	})
 
 	testCases = append(testCases, TestCase{
-		editorCmd: "subl -e 'unclosed single-quote",
+		editorCmd:  "subl -e 'unclosed single-quote",
 		executable: "",
-		args: []string{},
-		hasError: true,
+		args:       []string{},
+		hasError:   true,
 	})
 
 	testCases = append(testCases, TestCase{
-		editorCmd: "",
+		editorCmd:  "",
 		executable: "",
-		args: []string{},
-		hasError: true,
+		args:       []string{},
+		hasError:   true,
 	})
 
 	for _, testCase := range testCases {
@@ -338,14 +338,14 @@ func Test_parseEditorCommand(t *testing.T) {
 			t.Errorf("Error status did not match: %b: %s", testCase.hasError, err)
 		}
 		if executable != testCase.executable {
-			t.Errorf("Expected '%s', got '%s'", testCase.executable, executable) 
+			t.Errorf("Expected '%s', got '%s'", testCase.executable, executable)
 		}
 		if len(args) != len(testCase.args) {
 			t.Errorf("Expected and result args don't have the same length: [%s], [%s]", strings.Join(testCase.args, ", "), strings.Join(args, ", "))
 		}
 		for i, arg := range testCase.args {
 			if arg != args[i] {
-				t.Errorf("Expected and result args differ: [%s], [%s]", strings.Join(testCase.args, ", "), strings.Join(args, ", ")) 
+				t.Errorf("Expected and result args differ: [%s], [%s]", strings.Join(testCase.args, ", "), strings.Join(args, ", "))
 			}
 		}
 	}


### PR DESCRIPTION
When the list file contents page is generated with the header, there is whitespace on the breaking lines.

This causes problems when using vim with plugins which automatically flag or or remove whitespace, in my scenario [ntpeters/vim-better-whitespace](https://github.com/ntpeters/vim-better-whitespace)

Run go fmt, and fix tests.