### PR TITLE
Removed "go get" line from linux installation

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,8 +37,7 @@ If the installation fails, please follow the [instructions below](#building-from
 ### Linux
 
 - [Install Go](https://golang.org/doc/install#tarball)
-- Run `go get -u github.com/laurent22/massren`
-- Run `go install github.com/laurent22/massren`
+- Run `go install github.com/laurent22/massren@latest`
 
 By default, the tool will be installed in `$GOPATH/bin/massren`. From there, you can either symlink it to `/bin` or add `$GOPATH/bin` to your `PATH` variable with `export PATH=$PATH:$GOPATH/bin`.
 


### PR DESCRIPTION
That way to use "go get" is deprecated.
Output from go get:
	'go get' is no longer supported outside a module.
	To build and install a command, use 'go install' with a version,
	like 'go install example.com/cmd@latest'
	For more information, see https://golang.org/doc/go-get-install-deprecation