### PR TITLE
`massren .` to rename files in current directory

### DIFF
--- a/main.go
+++ b/main.go
@@ -265,7 +265,7 @@ func filePathsFromArgs(args []string, includeDirectories bool) ([]string, error)
 	var output []string
 	var err error
 
-	if len(args) == 0 {
+	if len(args) == 0 || args[0] == "." {
 		output, err = filepath.Glob("*")
 		if err != nil {
 			return []string{}, err

--- a/main_test.go
+++ b/main_test.go
@@ -679,10 +679,35 @@ func Test_filePathsFromArgs(t *testing.T) {
 		t.Error(err)
 	}
 
+	// "." (current directory) as the only file path argument works the same as "*"
+	currentDir, err := os.Getwd()
+	if err != nil {
+		panic(err)
+	}
+
+	err = os.Chdir(tempFolder())
+	if err != nil {
+		panic(err)
+	}
+
+	args = []string{"."}
+
+	filePaths, err = filePathsFromArgs(args, true)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = fileListsAreEqual(filePaths, tempFiles)
+	if err != nil {
+		t.Error(err)
+	}
+
+	os.Chdir(currentDir)
+
 	// If no argument is provided, the function should default to "*"
 	// in the current dir.
 
-	currentDir, err := os.Getwd()
+	currentDir, err = os.Getwd()
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
The "dot" metaphor for `cwd` (current working directory) is ubiquitous in shell usage.

This commit makes the command `massren .` open an editor with file listing in the current directory. i.e. equivalent functionality to `massren`.

Fixes #50